### PR TITLE
Add trix wysiwyg editor for moment body

### DIFF
--- a/app/javascript/components/MomentForm/index.jsx
+++ b/app/javascript/components/MomentForm/index.jsx
@@ -10,6 +10,7 @@ import Form from '../shared/Form';
 import Input from '../shared/Input';
 import Button from '../shared/Button';
 import DatePicker from '../shared/DatePicker';
+import WysiwygEditor from '../shared/WysiwygEditor';
 
 const MomentForm = ({ trackId }) => {
   const [errors, setErrors] = useState({});
@@ -51,14 +52,11 @@ const MomentForm = ({ trackId }) => {
             value={title}
           />
 
-          <Input
+          <WysiwygEditor
             id="body"
-            clearErrors={setErrors}
             errors={errors.body}
             label="Describe your moment..."
-            name="body"
             onChange={setBody}
-            value={body}
           />
 
           <DatePicker

--- a/app/javascript/components/shared/WysiwygEditor.jsx
+++ b/app/javascript/components/shared/WysiwygEditor.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { TrixEditor } from 'react-trix';
+
+const WysiwygEditor = (props) => {
+  const {
+    id,
+    errors,
+    helpText,
+    label,
+    onChange,
+  } = props;
+
+  useEffect(() => {
+    window.addEventListener('trix-file-accept', (event) => {
+      event.preventDefault();
+      alert('File attachment is not currently supported!');
+    });
+
+    return () => {
+      window.removeEventListener('trix-file-accept');
+    };
+  });
+
+  const handleChange = (html) => {
+    onChange(html);
+  };
+
+  return (
+    <div className="form-group">
+      <label htmlFor={id}>
+        {label}
+      </label>
+      <TrixEditor
+        onChange={handleChange}
+      />
+      {errors && (
+        <div className="invalid-feedback" style={{ display: 'block' }}>
+          {errors}
+        </div>
+      )}
+      {helpText && (
+        <small className="form-text text-muted">
+          {helpText}
+        </small>
+      )}
+    </div>
+  );
+};
+
+WysiwygEditor.defaultProps = {
+  id: '',
+  errors: null,
+  helpText: null,
+  label: '',
+};
+
+WysiwygEditor.propTypes = {
+  id: PropTypes.string,
+  errors: PropTypes.arrayOf(PropTypes.string),
+  helpText: PropTypes.string,
+  label: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default WysiwygEditor;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require('@rails/ujs').start();
 require('@rails/activestorage').start();
 require('channels');
 require('bootstrap');
+require('trix/dist/trix');
 
 // stylesheets
 require('react-dates/lib/css/_datepicker.css');

--- a/app/javascript/stylesheets/components/moment_card.scss
+++ b/app/javascript/stylesheets/components/moment_card.scss
@@ -1,10 +1,14 @@
 .track-card {
   border-radius: 15px;
   display: flex;
-  margin-bottom: 30px;
+  margin-bottom: 50px;
   box-shadow: rgba(0, 0, 0, 0.04) 0px 3px 5px;
-  max-width: 750px;
+  max-width: 600px;
   position: relative;
+
+  small {
+    font-size: 70%;
+  }
 
   .track-img-overlay {
     width: 200px;

--- a/app/javascript/stylesheets/components/trix.scss
+++ b/app/javascript/stylesheets/components/trix.scss
@@ -1,0 +1,3 @@
+.trix-button-group--file-tools {
+  display: none !important;
+}

--- a/app/javascript/stylesheets/main.scss
+++ b/app/javascript/stylesheets/main.scss
@@ -1,5 +1,12 @@
+// External
 @import "bootstrap/scss/bootstrap";
+@import "trix/dist/trix";
+
+// Base
 @import "base/general";
 @import "base/nav";
+
+// Components
+@import "components/trix";
 @import "components/datepicker";
 @import "components/moment_card";

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -8,18 +8,18 @@
 
 <% @track.moments.each do |moment| %>
   <div class="track-card">
-    <div class="track-img-overlay">
-    </div>
-
     <div class="track-img">
     </div>
 
     <div class="track-body">
-      <h4><%= moment.title %></h4>
-      <%= moment.body %> |
-      <small>
-        <%= moment.original_date.strftime("%m/%d/%Y") %>
-      </small>
+      <h4>
+        <%= moment.title %> |
+        <small>
+          <%= moment.original_date.strftime("%m/%d/%Y") %>
+        </small>
+      </h4>
+
+      <%= moment.body.html_safe %>
     </div>
   </div>
 <% end %>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dates": "^21.8.0",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-trix": "^0.8.0",
+    "trix": "^1.3.1"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/spec/features/moments/creating_a_moment_spec.rb
+++ b/spec/features/moments/creating_a_moment_spec.rb
@@ -21,7 +21,7 @@ feature "Creating a new moment", type: :feature do
       click_link "New Moment"
 
       fill_in "Title", with: "A moment"
-      fill_in "Describe your moment...", with: "Once upon a time..."
+      find("trix-editor").click.set("Once upon a time...")
 
       find(:css, "div.SingleDatePicker").click
       assert_text(:visible, Date.today.strftime("%B"))
@@ -35,7 +35,7 @@ feature "Creating a new moment", type: :feature do
     scenario "when the form data is invalid" do
       visit "/tracks/#{track.id}/moments/new"
 
-      fill_in "Describe your moment...", with: ""
+      find("trix-editor").click.set("")
       click_button "Create Moment"
 
       assert_text(:visible, "can't be blank")

--- a/spec/javascript/components/shared/WysiwygEditor.spec.jsx
+++ b/spec/javascript/components/shared/WysiwygEditor.spec.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { TrixEditor } from 'react-trix';
+import WysiwygEditor from 'shared/WysiwygEditor';
+
+configure({ adapter: new Adapter() });
+
+describe('WysiwygEditor', () => {
+  it('renders the TrixEditor component', () => {
+    const wrapper = shallow(
+      <WysiwygEditor
+        onChange={() => {}}
+      />,
+    );
+
+    expect(wrapper.find(TrixEditor).exists()).toEqual(true);
+  });
+
+  it('renders a label when provided', () => {
+    const wrapper = shallow(
+      <WysiwygEditor
+        id="moment"
+        label="Moment"
+        onChange={() => {}}
+      />,
+    );
+
+    expect(wrapper.containsMatchingElement(
+      <label htmlFor="moment">Moment</label>,
+    )).toEqual(true);
+  });
+
+  it('renders errors when provided', () => {
+    const wrapper = shallow(
+      <WysiwygEditor
+        errors={["can't be blank"]}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(wrapper.containsMatchingElement(
+      <div className="invalid-feedback">can&apos;t be blank</div>,
+    )).toEqual(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,6 +9138,13 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
+react-trix@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/react-trix/-/react-trix-0.8.0.tgz#0a629838ea73830253abc354212022678f8b50b0"
+  integrity sha512-sO5lUmxbvTsqCITHFvqeXjDfrvrS18sFbNUnBSC9fpLQlwN7x+B4QZbb8jtyCSZcR4J1/ghFtugPaV3891ymPg==
+  dependencies:
+    trix "^1.2.2"
+
 react-with-direction@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.3.1.tgz#9fd414564f0ffe6947e5ff176f6132dd83f8b8df"
@@ -10645,6 +10652,11 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trix@^1.2.2, trix@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.3.1.tgz#ccce8d9e72bf0fe70c8c019ff558c70266f8d857"
+  integrity sha512-BbH6mb6gk+AV4f2as38mP6Ucc1LE3OD6XxkZnAgPIduWXYtvg2mI3cZhIZSLqmMh9OITEpOBCCk88IVmyjU7bA==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
This commit updates the moment form to use basecamp's trix editor via the react-trix package. I haven't added support for attachments yet so it's been blocked.

<img width="510" alt="Screen Shot 2021-01-02 at 11 50 52 AM" src="https://user-images.githubusercontent.com/2301097/103465497-dd15fd80-4cf0-11eb-884f-c25ea73ec66b.png">