### PR TITLE
Fix issue with images not rendering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
           command: |
             sudo apt update
             sudo apt-get install -qq -o Acquire::Retries=3 imagemagick graphicsmagick
-            sudo apt-get install --fix-missing -qq -o Acquire::Retries=3 libvips
       - run:
           name: Swap node versions
           command: |

--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,0 @@
-libglib2.0-0
-libpoppler-glib8
-libvips

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -12,7 +12,7 @@
       <div class="flex-none w-48 rounded-l-md gradient-bg text-7xl text-white text-center leading-[192px]">
         <% if moment.feature_image.present? %>
           <%= image_tag(
-            moment.feature_image.variant(resize_to_limit: [600, 600]).processed,
+            moment.feature_image.url,
             alt: moment.title,
             class: "w-full h-full rounded-l-md object-cover"
           ) %>

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -12,7 +12,7 @@
       <div class="flex-none w-48 rounded-l-md gradient-bg text-7xl text-white text-center leading-[192px]">
         <% if moment.feature_image.present? %>
           <%= image_tag(
-            moment.feature_image.url,
+            url_for(moment.feature_image),
             alt: moment.title,
             class: "w-full h-full rounded-l-md object-cover"
           ) %>

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -80,7 +80,7 @@
 # generate variants to use image processing macros and ruby-vips
 # operations. See the upgrading guide for detail on the changes required.
 # The `:mini_magick` option is not deprecated; it's fine to keep using it.
-# Rails.application.config.active_storage.variant_processor = :vips
+Rails.application.config.active_storage.variant_processor = :vips
 
 # If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer
 # was `:marshal`. Convert all cookies to JSON, using the `:hybrid` formatter.

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -80,7 +80,7 @@
 # generate variants to use image processing macros and ruby-vips
 # operations. See the upgrading guide for detail on the changes required.
 # The `:mini_magick` option is not deprecated; it's fine to keep using it.
-Rails.application.config.active_storage.variant_processor = :vips
+Rails.application.config.active_storage.variant_processor = :mini_magick
 
 # If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer
 # was `:marshal`. Convert all cookies to JSON, using the `:hybrid` formatter.


### PR DESCRIPTION
This PR reverts some changes made during the Rails 7 upgrade to get images working. There is still an issue in production with image variants not working but this at least gets moments displaying again.